### PR TITLE
Use cp instead of sync for copy-to-s3.sh

### DIFF
--- a/src/copy-to-s3.sh
+++ b/src/copy-to-s3.sh
@@ -16,4 +16,4 @@ set -o xtrace
 readonly S3_DIRECTORY=${S3_DIRECTORY}
 readonly S3_TARGET=${S3_TARGET}
 
-aws s3 sync ${S3_DIRECTORY} ${S3_TARGET}
+aws s3 cp ${S3_DIRECTORY} ${S3_TARGET} --recursive


### PR DESCRIPTION
Uses `aws cp` instead of `aws sync` for the copy-to-s3 script. This is needed because we need for files to be uploaded each time even if they haven't changed to prevent them from expiring and being removed on S3. This also means the implementation matches more closely with the name to prevent confusion.